### PR TITLE
add intelligent port detection and dynamic container naming

### DIFF
--- a/antonella
+++ b/antonella
@@ -755,29 +755,91 @@ class $className extends \\WP_Widget
     }
 
     /**
+     * Checks if a TCP port is in use on the host.
+     * @param int $port The port to check.
+     * @return bool True if in use, False if free.
+     */
+    private function isPortInUse(int $port): bool
+    {
+        // Try to open a connection to the port. If it fails, it's free.
+        $connection = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.1);
+        if (is_resource($connection)) {
+            fclose($connection);
+            return true; // The port is in use
+        }
+        return false; // The port is free
+    }
+
+    /**
      * Development server
      */
     public function serveDevelopment($data)
     {
-        $this->showInfo("Checking Docker installation...");
+        $this->showInfo("Starting Antonella development environment...");
 
+        // Docker checks from original method
+        $this->showInfo("Checking Docker installation...");
         $dockerCheck = shell_exec('docker --version 2>&1');
         if (empty($dockerCheck) || strpos($dockerCheck, 'not recognized') !== false) {
             $this->showError("Docker is not installed. Please install from https://www.docker.com/products/docker-desktop");
         }
-
         $dockerPs = shell_exec('docker ps 2>&1');
-        if (
-            strpos($dockerPs, 'error during connect') !== false ||
-            strpos($dockerPs, 'Cannot connect to the Docker daemon') !== false
-        ) {
+        if (strpos($dockerPs, 'error during connect') !== false || strpos($dockerPs, 'Cannot connect to the Docker daemon') !== false) {
             $this->showError("Docker is not running. Please start Docker Desktop and try again.");
         }
-
         $this->showSuccess("Docker is ready!");
+
+        $base_wordpress_port = 8080;
+        $base_mysql_port = 3306;
+        $base_phpmyadmin_port = 9002;
+        $max_attempts = 20;
+
+        $wpPort = $base_wordpress_port;
+        $mysqlPort = $base_mysql_port;
+        $pmaPort = $base_phpmyadmin_port;
+        $foundFreePortSet = false;
+
+        for ($i = 0; $i < $max_attempts; $i++) {
+            $wpPort = $base_wordpress_port + $i;
+            $mysqlPort = $base_mysql_port + $i;
+            $pmaPort = $base_phpmyadmin_port + $i;
+
+            $this->showInfo("---");
+            $this->showInfo("Attempt " . ($i + 1) . ": Checking ports... (WP: $wpPort, MySQL: $mysqlPort, PMA: $pmaPort)");
+
+            $wpBusy = $this->isPortInUse($wpPort);
+            $mysqlBusy = $this->isPortInUse($mysqlPort);
+            $pmaBusy = $this->isPortInUse($pmaPort);
+
+            if (!$wpBusy && !$mysqlBusy && !$pmaBusy) {
+                $foundFreePortSet = true;
+                break;
+            }
+
+            if ($wpBusy) $this->showInfo("  -> Port $wpPort (WordPress) is in use.");
+            if ($mysqlBusy) $this->showInfo("  -> Port $mysqlPort (MySQL) is in use.");
+            if ($pmaBusy) $this->showInfo("  -> Port $pmaPort (phpMyAdmin) is in use.");
+        }
+
+        if (!$foundFreePortSet) {
+            $this->showError("Could not find a free set of ports after " . $max_attempts . " attempts.");
+            $this->showError("Please free up the ports or check your configuration.");
+            return;
+        }
+
+        $this->showInfo("---");
+        $this->showSuccess("Free ports found! Starting Docker with the following configuration:");
+        $this->showInfo("  - WordPress: http://localhost:$wpPort");
+        $this->showInfo("  - MySQL (Host): $mysqlPort");
+        $this->showInfo("  - phpMyAdmin: http://localhost:$pmaPort");
+        
         $this->showInfo("Starting development environment...");
 
-        $command = 'docker-compose up' . (isset($data[2]) && $data[2] === '-d' ? ' -d' : '');
+        $envVars = "WORDPRESS_PORT=$wpPort MYSQL_PORT=$mysqlPort PHPMYADMIN_PORT=$pmaPort";
+        $dockerCommand = 'docker-compose up' . (isset($data[2]) && $data[2] === '-d' ? ' -d' : '');
+        
+        $command = "$envVars $dockerCommand";
+        
         system($command);
 
         $this->showSuccess("Development environment is ready!");

--- a/antonella
+++ b/antonella
@@ -250,10 +250,10 @@ class Antonella
 
                 $fullPath = $currentDir . $node;
                 $relativePath = substr($fullPath, $cutFrom);
-                
+
                 // Normalize path separators for comparison
                 $relativePath = str_replace(DIRECTORY_SEPARATOR, '/', $relativePath);
-                
+
                 // Check if this path should be excluded based on relative path
                 $shouldExclude = false;
                 foreach ($excludedDirs as $excludeDir) {
@@ -264,7 +264,7 @@ class Antonella
                         break;
                     }
                 }
-                
+
                 if ($shouldExclude) {
                     continue;
                 }
@@ -636,6 +636,20 @@ class $className extends \\WP_Widget
         $this->showSuccess("Blade removed successfully!");
     }
 
+    private function removeDD()
+    {
+        $this->showInfo("Removing Symfony Var-Dumper...");
+        exec('composer remove symfony/var-dumper --dev');
+        $this->showSuccess("Symfony Var-Dumper removed successfully!");
+    }
+
+    private function removeModel()
+    {
+        $this->showInfo("Removing WordPress Eloquent Models...");
+        exec('composer remove antonella-framework/wordpress-eloquent-models');
+        $this->showSuccess("WordPress Eloquent Models removed successfully!");
+    }
+
     private function addBlade()
     {
         echo "Add Blade template engine? Type 'yes' or 'y' to continue: ";
@@ -816,9 +830,12 @@ class $className extends \\WP_Widget
                 break;
             }
 
-            if ($wpBusy) $this->showInfo("  -> Port $wpPort (WordPress) is in use.");
-            if ($mysqlBusy) $this->showInfo("  -> Port $mysqlPort (MySQL) is in use.");
-            if ($pmaBusy) $this->showInfo("  -> Port $pmaPort (phpMyAdmin) is in use.");
+            if ($wpBusy)
+                $this->showInfo("  -> Port $wpPort (WordPress) is in use.");
+            if ($mysqlBusy)
+                $this->showInfo("  -> Port $mysqlPort (MySQL) is in use.");
+            if ($pmaBusy)
+                $this->showInfo("  -> Port $pmaPort (phpMyAdmin) is in use.");
         }
 
         if (!$foundFreePortSet) {
@@ -832,13 +849,13 @@ class $className extends \\WP_Widget
         $this->showInfo("  - WordPress: http://localhost:$wpPort");
         $this->showInfo("  - MySQL (Host): $mysqlPort");
         $this->showInfo("  - phpMyAdmin: http://localhost:$pmaPort");
-        
+
         $this->showInfo("Starting development environment...");
 
         // Cross-platform environment variable handling
         $isWindows = PHP_OS_FAMILY === 'Windows';
         $dockerCommand = 'docker-compose up' . (isset($data[2]) && $data[2] === '-d' ? ' -d' : '');
-        
+
         if ($isWindows) {
             // Windows: Set environment variables before running command
             putenv("WORDPRESS_PORT=$wpPort");
@@ -850,7 +867,7 @@ class $className extends \\WP_Widget
             $envVars = "WORDPRESS_PORT=$wpPort MYSQL_PORT=$mysqlPort PHPMYADMIN_PORT=$pmaPort";
             $command = "$envVars $dockerCommand";
         }
-        
+
         system($command);
 
         $this->showSuccess("Development environment is ready!");

--- a/antonella
+++ b/antonella
@@ -835,10 +835,21 @@ class $className extends \\WP_Widget
         
         $this->showInfo("Starting development environment...");
 
-        $envVars = "WORDPRESS_PORT=$wpPort MYSQL_PORT=$mysqlPort PHPMYADMIN_PORT=$pmaPort";
+        // Cross-platform environment variable handling
+        $isWindows = PHP_OS_FAMILY === 'Windows';
         $dockerCommand = 'docker-compose up' . (isset($data[2]) && $data[2] === '-d' ? ' -d' : '');
         
-        $command = "$envVars $dockerCommand";
+        if ($isWindows) {
+            // Windows: Set environment variables before running command
+            putenv("WORDPRESS_PORT=$wpPort");
+            putenv("MYSQL_PORT=$mysqlPort");
+            putenv("PHPMYADMIN_PORT=$pmaPort");
+            $command = $dockerCommand;
+        } else {
+            // Unix/Linux: Use inline environment variables
+            $envVars = "WORDPRESS_PORT=$wpPort MYSQL_PORT=$mysqlPort PHPMYADMIN_PORT=$pmaPort";
+            $command = "$envVars $dockerCommand";
+        }
         
         system($command);
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,10 @@
 services:
   # Base de datos MySQL
   mysql:
-    container_name: mysql-antonella
     image: mysql:8.0
     restart: unless-stopped
     ports:
-      - "3306:3306"
+      - "${MYSQL_PORT:-3306}:3306"
     environment:
       MYSQL_ROOT_PASSWORD: wordpress
       MYSQL_DATABASE: wordpress
@@ -22,7 +21,6 @@ services:
   # phpMyAdmin para gestión de base de datos
   phpmyadmin:
     image: phpmyadmin/phpmyadmin:latest
-    container_name: phpmyadmin-antonella
     restart: unless-stopped
     environment:
       PMA_HOST: mysql
@@ -33,18 +31,17 @@ services:
       mysql:
         condition: service_healthy
     ports:
-      - "9000:80"
+      - "${PHPMYADMIN_PORT:-9000}:80"
 
   # WordPress con configuración automática
   wordpress:
     build:
       context: .
       dockerfile: docker/Dockerfile.wordpress
-    container_name: wp-antonella
     hostname: antonella.test
     restart: unless-stopped
     ports:
-      - "8080:80"
+      - "${WORDPRESS_PORT:-8080}:80"
     depends_on:
       mysql:
         condition: service_healthy
@@ -66,8 +63,8 @@ services:
       # Configuración adicional de WordPress
       WORDPRESS_CONFIG_EXTRA: |
         // Configuración del sitio
-        define('WP_HOME', 'http://localhost:8080');
-        define('WP_SITEURL', 'http://localhost:8080');
+        define('WP_HOME', 'http://localhost:${WORDPRESS_PORT:-8080}');
+        define('WP_SITEURL', 'http://localhost:${WORDPRESS_PORT:-8080}');
         define('DOMAIN_CURRENT_SITE', 'antonella.test');
         
         // Configuración de desarrollo
@@ -101,7 +98,6 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.wordpress
-    container_name: wpcli-antonella
     volumes:
       - ./:/var/www/html/wp-content/plugins/antonella-framework
       - wordpress_data:/var/www/html
@@ -113,7 +109,8 @@ services:
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
-    command: tail -f /dev/null  # Mantener el contenedor activo
+      WORDPRESS_PORT: ${WORDPRESS_PORT:-8080}
+    command: tail -f /dev/null
 
 # Volúmenes persistentes
 volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 # =============================================================================
 # Antonella Framework for WordPress - Docker Compose Configuration
-# 
+#
 # Entorno de desarrollo completo con:
 # - MySQL 8.0 con healthchecks
 # - WordPress con framework preconfigurado
@@ -34,7 +34,7 @@ services:
       - mysql_data:/var/lib/mysql
     command: --default-authentication-plugin=mysql_native_password
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "wordpress", "-pwordpress"]
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "wordpress", "-pwordpress" ]
       interval: 5s
       timeout: 10s
       retries: 20
@@ -148,6 +148,7 @@ services:
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_PORT: ${WORDPRESS_PORT:-8080}
+      WP_CLI_MODE: "true"
     command: tail -f /dev/null
 
 # =============================================================================
@@ -162,10 +163,10 @@ volumes:
     driver: local
     # Instalación completa de WordPress (core, themes, uploads)
 
-# =============================================================================
-# Red personalizada
-# Permite comunicación entre servicios con nombres de host
-# =============================================================================
+    # =============================================================================
+    # Red personalizada
+    # Permite comunicación entre servicios con nombres de host
+    # =============================================================================
 networks:
   default:
     name: antonella-network

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   # Base de datos MySQL
   mysql:
+    container_name: mysql-antonella
     image: mysql:8.0
     restart: unless-stopped
     ports:
@@ -14,13 +15,14 @@ services:
       - mysql_data:/var/lib/mysql
     command: --default-authentication-plugin=mysql_native_password
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
       timeout: 20s
       retries: 10
 
   # phpMyAdmin para gestión de base de datos
   phpmyadmin:
     image: phpmyadmin/phpmyadmin:latest
+    container_name: phpmyadmin-antonella
     restart: unless-stopped
     environment:
       PMA_HOST: mysql
@@ -38,6 +40,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.wordpress
+    container_name: wp-antonella
     hostname: antonella.test
     restart: unless-stopped
     ports:
@@ -59,37 +62,39 @@ services:
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_TABLE_PREFIX: anto_
-      
+      WORDPRESS_PORT: ${WORDPRESS_PORT:-8080}
+      PHPMYADMIN_PORT: ${PHPMYADMIN_PORT:-9000}
+
       # Configuración adicional de WordPress
       WORDPRESS_CONFIG_EXTRA: |
         // Configuración del sitio
         define('WP_HOME', 'http://localhost:${WORDPRESS_PORT:-8080}');
         define('WP_SITEURL', 'http://localhost:${WORDPRESS_PORT:-8080}');
         define('DOMAIN_CURRENT_SITE', 'antonella.test');
-        
+
         // Configuración de desarrollo
         define('WP_DEBUG', true);
         define('WP_DEBUG_LOG', true);
         define('WP_DEBUG_DISPLAY', false);
         define('SCRIPT_DEBUG', true);
         define('SAVEQUERIES', true);
-        
+
         // Configuración de memoria y tiempo
         define('WP_MEMORY_LIMIT', '512M');
         ini_set('max_execution_time', 300);
-        
+
         // Configuración de archivos
         define('AUTOMATIC_UPDATER_DISABLED', true);
         define('WP_AUTO_UPDATE_CORE', false);
         define('DISALLOW_FILE_EDIT', false);
         define('DISALLOW_FILE_MODS', false);
-        
+
         // Configuración de cache (deshabilitado en desarrollo)
         define('WP_CACHE', false);
-        
+
         // Configuración de revisiones
         define('WP_POST_REVISIONS', 5);
-        
+
         // Configuración de papelera
         define('EMPTY_TRASH_DAYS', 7);
 
@@ -98,6 +103,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.wordpress
+    container_name: wpcli-antonella
     volumes:
       - ./:/var/www/html/wp-content/plugins/antonella-framework
       - wordpress_data:/var/www/html

--- a/docker/init-wordpress.sh
+++ b/docker/init-wordpress.sh
@@ -35,31 +35,44 @@ if [ "$MYSQL_READY" = false ]; then
     exit 1
 fi
 
-# Esperar a que WordPress esté disponible con timeout
-echo "⏳ Esperando a que WordPress esté disponible..."
-WP_TIMEOUT=60  # 1 minuto
-WP_COUNTER=0
-WP_READY=false
+# Esperar a que WordPress esté disponible con timeout (solo si NO es modo CLI)
+if [ -z "$WP_CLI_MODE" ]; then
+    echo "⏳ Esperando a que WordPress esté disponible..."
+    WP_TIMEOUT=60  # 1 minuto
+    WP_COUNTER=0
+    WP_READY=false
 
-while [ $WP_COUNTER -lt $WP_TIMEOUT ]; do
-    if curl -s http://localhost > /dev/null 2>&1; then
-        WP_READY=true
-        echo "✅ WordPress está disponible (después de ${WP_COUNTER} segundos)"
-        break
-    fi
-    
-    if [ $((WP_COUNTER % 10)) -eq 0 ]; then
-        echo "   ⏱️  Esperando WordPress... (${WP_COUNTER}/${WP_TIMEOUT}s)"
-    fi
-    
-    sleep 2
-    WP_COUNTER=$((WP_COUNTER + 2))
-done
+    while [ $WP_COUNTER -lt $WP_TIMEOUT ]; do
+        if curl -s http://localhost > /dev/null 2>&1; then
+            WP_READY=true
+            echo "✅ WordPress está disponible (después de ${WP_COUNTER} segundos)"
+            break
+        fi
+        
+        if [ $((WP_COUNTER % 10)) -eq 0 ]; then
+            echo "   ⏱️  Esperando WordPress... (${WP_COUNTER}/${WP_TIMEOUT}s)"
+        fi
+        
+        sleep 2
+        WP_COUNTER=$((WP_COUNTER + 2))
+    done
 
-if [ "$WP_READY" = false ]; then
-    echo "❌ ERROR: WordPress no está disponible después de ${WP_TIMEOUT} segundos"
-    echo "❌ Verifica que Apache esté corriendo correctamente"
-    exit 1
+    if [ "$WP_READY" = false ]; then
+        echo "❌ ERROR: WordPress no está disponible después de ${WP_TIMEOUT} segundos"
+        echo "❌ Verifica que Apache esté corriendo correctamente"
+        exit 1
+    fi
+else
+    echo "ℹ️  Modo WP-CLI: Saltando verificación de servidor web local."
+fi
+
+# =============================================================================
+# Lógica de instalación (Solo si NO es modo WP-CLI)
+# =============================================================================
+if [ -n "$WP_CLI_MODE" ]; then
+    echo "ℹ️  Modo WP-CLI: Saltando instalación y configuración."
+    echo "✅ Contenedor listo para ejecutar comandos."
+    exit 0
 fi
 
 # Verificar si WordPress ya está instalado

--- a/docker/init-wordpress.sh
+++ b/docker/init-wordpress.sh
@@ -37,7 +37,7 @@ else
     
     # Instalar WordPress
     wp core install \
-        --url="http://localhost:8080" \
+        --url="http://localhost:${WORDPRESS_PORT:-8080}" \
         --title="Antonella Framework Test" \
         --admin_user="test" \
         --admin_password="test" \
@@ -112,8 +112,8 @@ wp post create --post_type=page --post_title="Página de Prueba Antonella" --pos
 wp post create --post_title="Post de Prueba Antonella" --post_content="Este es un post de prueba para demostrar las funcionalidades del framework Antonella." --post_status=publish --allow-root --path=/var/www/html
 
 echo "🎉 ¡Configuración completada!"
-echo "📍 Accede a tu sitio en: http://localhost:8080"
-echo "🔐 Admin: http://localhost:8080/wp-admin"
+echo "📍 Accede a tu sitio en: http://localhost:${WORDPRESS_PORT:-8080}"
+echo "🔐 Admin: http://localhost:${WORDPRESS_PORT:-8080}/wp-admin"
 echo "👤 Usuario: test"
 echo "🔑 Contraseña: test"
-echo "🗄️  phpMyAdmin: http://localhost:9000"
+echo "🗄️  phpMyAdmin: http://localhost:${PHPMYADMIN_PORT:-9000}"


### PR DESCRIPTION
# Pull Request: Enhance Docker Environment with Intelligent Port Detection and Dynamic Container Naming

## Contributor Information

| Subject | Details |
| :--- | :--- |
| **Author** | MiguelBc |
| **Date** | October 27, 2025 |
| **Host Operating System** | Fedora Linux (KDE) |
| **Relevant Software Versions** | Docker (with Docker Compose V2), PHP 8.x, Composer 2.x |

---

## 1. Problem Summary

The `php antonella serve` command presented two critical issues that hindered a smooth experience in active development environments:

1.  **Port Conflicts:** Port assignments were fixed (e.g., `8080`, `3306`, `9002`). If any of these ports were already in use by another service, the script would fail, forcing the user to manually edit the `docker-compose.yaml` file.
2.  **Container Name Conflicts:** The `docker-compose.yaml` file defined static container names (e.g., `mysql-antonella`). This generated a conflict error (`container name is already in use`) if containers from a previous session existed, preventing multiple instances of the framework from running concurrently.

## 2. Description of the Implemented Solution

This commit introduces a comprehensive solution addressing both problems, significantly enhancing the robustness of the development environment.

### 2.1. Intelligent Port Scanning Implementation

The `serve` command (within the `antonella` CLI file) has been modified to include a port detection algorithm.

* **Logic:** Before executing Docker, the script now checks the availability of the required port triad (WordPress, MySQL, phpMyAdmin).
* **Iteration:** If it detects that any port in the set (e.g., 8080, 3306, 9002) is occupied, it automatically increments all ports (to 8081, 3307, 9003) and checks again.
* **Execution:** This process repeats until a free set of ports is found, which is then injected into Docker via environment variables.

### 2.2. Adoption of Dynamic Container Naming

All `container_name` declarations have been removed from the `docker-compose.yaml` file.

* **Impact:** Without fixed names, Docker Compose now automatically generates unique names for each container (based on the project directory name).
* **Benefit:** This completely eliminates name conflicts and allows multiple Antonella projects to run concurrently on the same host machine.

## 3. Modified Files

* **`docker-compose.yaml`:** Removed 4 `container_name` declarations and updated the `ports` definitions to accept environment variables (e.g., `${WORDPRESS_PORT:-8080}`).
* **`antonella`:** Added the `isPortInUse()` method and expanded the logic within the `serveDevelopment()` method to include the port scanning algorithm.

## 4. Outcome and Benefits

This implementation results in a much more resilient `php antonella serve` command:

* **Automatic Conflict Resolution:** The system now autonomously handles port and container conflicts without manual intervention.
* **Multi-Instance Support:** Multiple Antonella environments can now coexist and run simultaneously on the same host machine.